### PR TITLE
Add some documentation about using GSAPv3Middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ import * as dat from 'dat.gui';
 import datGuiEase from 'dat.gui.ease';
 import styles from 'dat.gui.ease/dist/dat.gui.ease.css';
 ```
+
+
 3. CommonJS
 ```javascript
 const dat = require('dat.gui');
@@ -58,7 +60,18 @@ gui.addEase({ ease: Power2.easeIn }, "ease"); // Voila! Ease is editable in dat.
 ```
 <br>
 
-#### Credits
+### Common issue
+#### Missing styles (es6)
+
+```javascript
+// build tools with treeshaking might ignore the following statement
+import styles from 'dat.gui.ease/dist/dat.gui.ease.css';
+
+// use this instead
+import 'dat.gui.ease/dist/dat.gui.ease.css'
+```
+
+### Credits
 
 [SidneyDouw/curvesjs](https://github.com/SidneyDouw/curvesjs) - minimalistic yet nonetheless powerful bezier curve editor with no dependencies - exactly what I've looked for. Hope it gets more attention.
 

--- a/packages/gsap-v3/README.md
+++ b/packages/gsap-v3/README.md
@@ -42,3 +42,18 @@ const middleware = new GSAPv3Middleware();
 const datGuiEaseGsapV3 = require('dat.gui.ease.gsap.v3');
 const middleware = new datGuiEaseGsapV3.Middleware();
 ```
+
+## Adding ease gui
+1. Standard ease
+```javascript
+let gui = new dat.GUI();
+gui.addEase({ ease: "power1.out" }, "ease");
+```
+
+
+2. Custom ease
+```javascript
+let gui = new dat.GUI();
+let myCustomEase = new CustomEase("myCustomEaseName", "M0,0,C0.036,0.208,0.216,0.488,0.486,0.488,0.742,0.488,1,0.362,1,0.01");
+gui.addEase({ ease: myCustomEase }, "ease");
+```


### PR DESCRIPTION
Hi !
Pretty neat library. Exactly what we looking for ! so... many thanks !

I struggled a bit for setuping `GSAPv3Middleware`.
Essentially because it lacked some `.addEase()` documentation. 
I based myself on the documentation of `GSAPv2Middleware` but it leads to '"No compatible middleware found."'

This documentation addition might not perfectly fit the structure, but at least this could be useful for other people.

Thanks!